### PR TITLE
Update SecretsListActivity.java

### DIFF
--- a/app/src/main/java/net/tawacentral/roger/secrets/SecretsListActivity.java
+++ b/app/src/main/java/net/tawacentral/roger/secrets/SecretsListActivity.java
@@ -151,7 +151,10 @@ public class SecretsListActivity extends ListActivity {
     setTitle();
 
     setListAdapter(secretsList);
-    getListView().setTextFilterEnabled(true);
+    final ListView listView = getListView();
+    listView.setTextFilterEnabled(true);
+    listView.setFastScrollEnabled(true);
+    listView.setFastScrollAlwaysVisible(true);
 
     // Setup the auto complete adapters for the username and email views.
     AutoCompleteTextView username =


### PR DESCRIPTION
For folks (like me) who have a large number of secrets, this makes it easy to scroll through the list, without taking up significant real estate. If you find the always-visible thumb objectionable, drop the call to setFastScrollAlwaysVisible(true).
